### PR TITLE
fix: expose totaal_kosten at afval profiel level

### DIFF
--- a/src/openafval/afval/api/serializers.py
+++ b/src/openafval/afval/api/serializers.py
@@ -74,3 +74,4 @@ class AfvalProfielSerializer(serializers.Serializer):
     containers = ContainerSerializer(many=True)
     container_locaties = ContainerLocationSerializer(many=True)
     ledigingen = LedigingSerializer(many=True)
+    totaal_kosten = serializers.FloatField()

--- a/src/openafval/afval/api/views.py
+++ b/src/openafval/afval/api/views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from django.db.models import Sum
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
@@ -93,6 +94,7 @@ class AfvalProfielAPIView(views.APIView):
         containers = containers_filter.qs
         container_locaties = container_locaties_filter.qs
         ledigingen = ledigingen_filter.qs
+        totaal_kosten = ledigingen.aggregate(totaal=Sum("kosten"))["totaal"] or 0.0
 
         # serialize for response
         try:
@@ -102,6 +104,7 @@ class AfvalProfielAPIView(views.APIView):
                     "containers": containers,
                     "container_locaties": container_locaties,
                     "ledigingen": ledigingen,
+                    "totaal_kosten": totaal_kosten,
                 }
             )
         except (KeyError, AttributeError, TypeError) as exc:

--- a/src/openafval/afval/tests/test_api.py
+++ b/src/openafval/afval/tests/test_api.py
@@ -48,6 +48,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
         self.assertEqual(data["containers"], [])
         self.assertEqual(data["containerLocaties"], [])
         self.assertEqual(data["ledigingen"], [])
+        self.assertEqual(data["totaalKosten"], 0.0)
 
     def test_afval_profiel_structure(self):
         klant = KlantFactory.create(bsn="123456789", naam="Jan Jansen")
@@ -167,6 +168,8 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
                 }
             ],
         )
+
+        self.assertEqual(data["totaalKosten"], 15.0)  # 3 + 5 + 7
 
     def test_isolation_between_klanten(self):
         """
@@ -372,6 +375,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
 
         # Check ledigingen count
         self.assertEqual(len(data["ledigingen"]), 5)
+        self.assertEqual(data["totaalKosten"], 15.0)  # 1 + 2 + 3 + 4 + 5
 
     def test_response_contains_all_required_fields(self):
         klant = KlantFactory.create(bsn="123456789", naam="Test Klant")
@@ -440,6 +444,8 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
         self.assertEqual(lediging["gewicht"], 42.5)
         self.assertEqual(lediging["kosten"], 5.50)
         self.assertEqual(lediging["geleegdOp"], "2026-01-15T14:30:00+01:00")
+
+        self.assertEqual(data["totaalKosten"], 5.5)
 
     def test_filter_by_afval_type(self):
         klant = KlantFactory.create(bsn="123456789")


### PR DESCRIPTION
Sum kosten across all filtered ledigingen and include it as `totaalKosten` in the top-level AfvalProfiel response, alongside the existing per-container and per-location totals.

Fixes https://github.com/maykinmedia/open-inwoner/issues/2657
