### PR TITLE
fix: expose totaal_kosten at klant level

### DIFF
--- a/src/openafval/afval/api/serializers.py
+++ b/src/openafval/afval/api/serializers.py
@@ -40,12 +40,15 @@ class ContainerLocationSerializer(serializers.ModelSerializer):
 
 
 class KlantSerializer(serializers.ModelSerializer):
+    totaal_kosten = serializers.FloatField(read_only=True)
+
     class Meta:  # pyright: ignore
         model = Klant
         fields = (
             "id",
             "bsn",
             "naam",
+            "totaal_kosten",
         )
         read_only_fields = fields
 
@@ -74,4 +77,3 @@ class AfvalProfielSerializer(serializers.Serializer):
     containers = ContainerSerializer(many=True)
     container_locaties = ContainerLocationSerializer(many=True)
     ledigingen = LedigingSerializer(many=True)
-    totaal_kosten = serializers.FloatField()

--- a/src/openafval/afval/api/views.py
+++ b/src/openafval/afval/api/views.py
@@ -94,7 +94,7 @@ class AfvalProfielAPIView(views.APIView):
         containers = containers_filter.qs
         container_locaties = container_locaties_filter.qs
         ledigingen = ledigingen_filter.qs
-        totaal_kosten = ledigingen.aggregate(totaal=Sum("kosten"))["totaal"] or 0.0
+        klant.totaal_kosten = ledigingen.aggregate(totaal=Sum("kosten"))["totaal"] or 0.0
 
         # serialize for response
         try:
@@ -104,7 +104,6 @@ class AfvalProfielAPIView(views.APIView):
                     "containers": containers,
                     "container_locaties": container_locaties,
                     "ledigingen": ledigingen,
-                    "totaal_kosten": totaal_kosten,
                 }
             )
         except (KeyError, AttributeError, TypeError) as exc:

--- a/src/openafval/afval/tests/test_api.py
+++ b/src/openafval/afval/tests/test_api.py
@@ -41,6 +41,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
                 "id": str(klant.id),
                 "bsn": klant.bsn,
                 "naam": klant.naam,
+                "totaalKosten": 0.0,
             },
         )
 
@@ -48,7 +49,6 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
         self.assertEqual(data["containers"], [])
         self.assertEqual(data["containerLocaties"], [])
         self.assertEqual(data["ledigingen"], [])
-        self.assertEqual(data["totaalKosten"], 0.0)
 
     def test_afval_profiel_structure(self):
         klant = KlantFactory.create(bsn="123456789", naam="Jan Jansen")
@@ -93,6 +93,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
                 "id": str(klant.id),
                 "bsn": klant.bsn,
                 "naam": klant.naam,
+                "totaalKosten": 15.0,  # 3 + 5 + 7
             },
         )
 
@@ -168,8 +169,6 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
                 }
             ],
         )
-
-        self.assertEqual(data["totaalKosten"], 15.0)  # 3 + 5 + 7
 
     def test_isolation_between_klanten(self):
         """
@@ -375,7 +374,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
 
         # Check ledigingen count
         self.assertEqual(len(data["ledigingen"]), 5)
-        self.assertEqual(data["totaalKosten"], 15.0)  # 1 + 2 + 3 + 4 + 5
+        self.assertEqual(data["klant"]["totaalKosten"], 15.0)  # 1 + 2 + 3 + 4 + 5
 
     def test_response_contains_all_required_fields(self):
         klant = KlantFactory.create(bsn="123456789", naam="Test Klant")
@@ -404,6 +403,7 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
                 "id": str(klant.id),
                 "bsn": klant.bsn,
                 "naam": klant.naam,
+                "totaalKosten": 5.5,
             },
         )
 
@@ -444,8 +444,6 @@ class AfvalProfielAPITest(TokenAuthMixin, APITestCase):
         self.assertEqual(lediging["gewicht"], 42.5)
         self.assertEqual(lediging["kosten"], 5.50)
         self.assertEqual(lediging["geleegdOp"], "2026-01-15T14:30:00+01:00")
-
-        self.assertEqual(data["totaalKosten"], 5.5)
 
     def test_filter_by_afval_type(self):
         klant = KlantFactory.create(bsn="123456789")


### PR DESCRIPTION
Move `totaalKosten` from the top-level `AfvalProfiel` response into the klant resource.

