### PR TITLE
Fix drift in WK column names

### DIFF
--- a/src/openafval/afval/services/import_services.py
+++ b/src/openafval/afval/services/import_services.py
@@ -57,15 +57,15 @@ class FTPSConfig(TypedDict):
 
 DTYPE_MAPPING = {
     "BSN": str,
-    "CONTAINERID": str,
-    "FRACTIEID": str,
+    "CONTAINER_ID": str,
+    "FRACTIE_ID": str,
     "GEWICHT_ONVERDEELD": float,
     "GEWICHT_VERDEELD": float,
-    "LEDIGINGID": str,
+    "LEDIGING_ID": str,
     "OBJECTADRES": str,
-    "OBJECTID": str,
+    "OBJECT_ID": str,
     "SLEUTELNUMMER": str,
-    "SUBJECTID": str,
+    "SUBJECT_ID": str,
     "SUBJECTNAAM": str,
     "VERZAMELCONTAINER_J_N": str,
     "TOTAALKOSTEN_LEDIGING": float,
@@ -121,11 +121,11 @@ def import_from_csv_stream(stream: IO[str], chunk_size: int | None = None):
     logger.info("Starting CSV import with chunk size: %s", f"{chunk_size:,}")
 
     # First pass: collect unique entities across all chunks
-    unique_locations_dict: dict[str, str] = {}  # OBJECTID -> OBJECTADRES
-    unique_klanten_dict: dict[str, tuple[str, str]] = {}  # SUBJECTID -> (BSN, NAAM)
+    unique_locations_dict: dict[str, str] = {}  # OBJECT_ID -> OBJECTADRES
+    unique_klanten_dict: dict[str, tuple[str, str]] = {}  # SUBJECT_ID -> (BSN, NAAM)
     unique_containers_dict: dict[
         str, tuple[str, bool, bool]
-    ] = {}  # CONTAINERID -> (afval_type, is_verzamelcontainer, heeft_sleutel)
+    ] = {}  # CONTAINER_ID -> (afval_type, is_verzamelcontainer, heeft_sleutel)
 
     # Process CSV in chunks for first pass
     logger.info("First pass: collecting unique entities from CSV")
@@ -137,7 +137,7 @@ def import_from_csv_stream(stream: IO[str], chunk_size: int | None = None):
         chunksize=chunk_size,
     )
 
-    _REQUIRED_COLUMNS = ["BSN", "LEDIGINGSMOMENT", "CONTAINERID", "OBJECTID", "SUBJECTID"]
+    _REQUIRED_COLUMNS = ["BSN", "LEDIGINGSMOMENT", "CONTAINER_ID", "OBJECT_ID", "SUBJECT_ID"]
 
     chunk_count = 0
     total_rows_processed = 0
@@ -158,30 +158,30 @@ def import_from_csv_stream(stream: IO[str], chunk_size: int | None = None):
         )
 
         # Pre-process columns
-        chunk_df["afval_type"] = chunk_df["FRACTIEID"].apply(_map_fractie_id_to_afval_type)
+        chunk_df["afval_type"] = chunk_df["FRACTIE_ID"].apply(_map_fractie_id_to_afval_type)
         chunk_df["is_verzamelcontainer"] = chunk_df["VERZAMELCONTAINER_J_N"].apply(_csv_boolean)
         chunk_df["heeft_sleutel"] = chunk_df["SLEUTELNUMMER"].notna() & (
             chunk_df["SLEUTELNUMMER"] != ""
         )
 
         # Collect unique entities from this chunk
-        for row in chunk_df[["OBJECTID", "OBJECTADRES"]].drop_duplicates().itertuples(index=False):
-            if row.OBJECTID not in unique_locations_dict:
-                unique_locations_dict[row.OBJECTID] = row.OBJECTADRES
+        for row in chunk_df[["OBJECT_ID", "OBJECTADRES"]].drop_duplicates().itertuples(index=False):
+            if row.OBJECT_ID not in unique_locations_dict:
+                unique_locations_dict[row.OBJECT_ID] = row.OBJECTADRES
 
         for row in (
-            chunk_df[["SUBJECTID", "BSN", "SUBJECTNAAM"]].drop_duplicates().itertuples(index=False)
+            chunk_df[["SUBJECT_ID", "BSN", "SUBJECTNAAM"]].drop_duplicates().itertuples(index=False)
         ):
-            if row.SUBJECTID not in unique_klanten_dict:
-                unique_klanten_dict[row.SUBJECTID] = (row.BSN, row.SUBJECTNAAM)
+            if row.SUBJECT_ID not in unique_klanten_dict:
+                unique_klanten_dict[row.SUBJECT_ID] = (row.BSN, row.SUBJECTNAAM)
 
         for row in (
-            chunk_df[["CONTAINERID", "afval_type", "is_verzamelcontainer", "heeft_sleutel"]]
+            chunk_df[["CONTAINER_ID", "afval_type", "is_verzamelcontainer", "heeft_sleutel"]]
             .drop_duplicates()
             .itertuples(index=False)
         ):
-            if row.CONTAINERID not in unique_containers_dict:
-                unique_containers_dict[row.CONTAINERID] = (
+            if row.CONTAINER_ID not in unique_containers_dict:
+                unique_containers_dict[row.CONTAINER_ID] = (
                     row.afval_type,
                     row.is_verzamelcontainer,
                     row.heeft_sleutel,
@@ -285,18 +285,18 @@ def import_from_csv_stream(stream: IO[str], chunk_size: int | None = None):
         # Create Lediging objects for this chunk
         ledigingen_batch = [
             Lediging(
-                container_location=container_location_mapping[row.OBJECTID],
-                klant=klant_mapping[row.SUBJECTID],
-                container=container_mapping[row.CONTAINERID],
+                container_location=container_location_mapping[row.OBJECT_ID],
+                klant=klant_mapping[row.SUBJECT_ID],
+                container=container_mapping[row.CONTAINER_ID],
                 gewicht=row.GEWICHT_VERDEELD,
                 geleegd_op=row.geleegd_op_utc,
                 kosten=Decimal(str(row.TOTAALKOSTEN_LEDIGING)),
             )
             for row in chunk_df[
                 [
-                    "OBJECTID",
-                    "SUBJECTID",
-                    "CONTAINERID",
+                    "OBJECT_ID",
+                    "SUBJECT_ID",
+                    "CONTAINER_ID",
                     "GEWICHT_VERDEELD",
                     "geleegd_op_utc",
                     "TOTAALKOSTEN_LEDIGING",

--- a/src/openafval/afval/tests/test_import.py
+++ b/src/openafval/afval/tests/test_import.py
@@ -16,8 +16,8 @@ class ImportFromCSVStreamTest(TestCase):
     def test_import_with_all_columns_populated(self):
         """Test importing CSV data with all columns properly populated."""
         csv_header = (
-            "SUBJECTID;BSN;SUBJECTNAAM;OBJECTID;OBJECTADRES;CONTAINERID;"
-            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIEID;LEDIGINGID;"
+            "SUBJECT_ID;BSN;SUBJECTNAAM;OBJECT_ID;OBJECTADRES;CONTAINER_ID;"
+            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIE_ID;LEDIGING_ID;"
             "GEWICHT_ONVERDEELD;GEWICHT_VERDEELD;LEDIGINGSMOMENT;TOTAALKOSTEN_LEDIGING"
         )
         csv_rows = [
@@ -62,7 +62,7 @@ class ImportFromCSVStreamTest(TestCase):
         self.assertEqual(container_with_key.count(), 2)
         verzamelcontainers = Container.objects.filter(is_verzamelcontainer=True)
         self.assertEqual(verzamelcontainers.count(), 1)
-        # Verify public_container_id is set from CONTAINERID column
+        # Verify public_container_id is set from CONTAINER_ID column
         self.assertCountEqual(
             Container.objects.values_list("public_container_id", flat=True),
             ["CONT001", "CONT002", "CONT003"],
@@ -81,8 +81,8 @@ class ImportFromCSVStreamTest(TestCase):
     def test_import_filters_null_bsn_and_ledigingsmoment(self):
         """Test that rows with null BSN or LEDIGINGSMOMENT are excluded."""
         csv_header = (
-            "SUBJECTID;BSN;SUBJECTNAAM;OBJECTID;OBJECTADRES;CONTAINERID;"
-            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIEID;LEDIGINGID;"
+            "SUBJECT_ID;BSN;SUBJECTNAAM;OBJECT_ID;OBJECTADRES;CONTAINER_ID;"
+            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIE_ID;LEDIGING_ID;"
             "GEWICHT_ONVERDEELD;GEWICHT_VERDEELD;LEDIGINGSMOMENT;TOTAALKOSTEN_LEDIGING"
         )
         csv_rows = [
@@ -134,8 +134,8 @@ class ImportFromCSVStreamTest(TestCase):
     def test_import_missing_kosten_defaults_to_zero(self):
         """Test that rows with a missing TOTAALKOSTEN_LEDIGING value default to 0."""
         csv_header = (
-            "SUBJECTID;BSN;SUBJECTNAAM;OBJECTID;OBJECTADRES;CONTAINERID;"
-            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIEID;LEDIGINGID;"
+            "SUBJECT_ID;BSN;SUBJECTNAAM;OBJECT_ID;OBJECTADRES;CONTAINER_ID;"
+            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIE_ID;LEDIGING_ID;"
             "GEWICHT_ONVERDEELD;GEWICHT_VERDEELD;LEDIGINGSMOMENT;TOTAALKOSTEN_LEDIGING"
         )
         csv_rows = [
@@ -154,8 +154,8 @@ class ImportFromCSVCommandTest(TestCase):
     def test_command_imports_csv_file_end_to_end(self):
         """Test that the command successfully imports a CSV file."""
         csv_header = (
-            "SUBJECTID;BSN;SUBJECTNAAM;OBJECTID;OBJECTADRES;CONTAINERID;"
-            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIEID;LEDIGINGID;"
+            "SUBJECT_ID;BSN;SUBJECTNAAM;OBJECT_ID;OBJECTADRES;CONTAINER_ID;"
+            "SLEUTELNUMMER;VERZAMELCONTAINER_J_N;FRACTIE_ID;LEDIGING_ID;"
             "GEWICHT_ONVERDEELD;GEWICHT_VERDEELD;LEDIGINGSMOMENT;TOTAALKOSTEN_LEDIGING"
         )
         csv_rows = [


### PR DESCRIPTION
The CSV export's column names had drifted from what the importer expected (O`BJECTID`, `SUBJECTID` etc. vs. the actual underscored `OBJECT_ID`, `SUBJECT_ID` etc.), so imports were silently failing to pick up dtype/column mappings for these fields.