### PR TITLE
Disable OAS linting

### DIFF
--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,28 +1,28 @@
-name: OAS
-
-on:
-  push:
-    branches:
-      - main
-      - stable/*
-    tags:
-      - '*'
-  pull_request:
-  workflow_dispatch:
-
-jobs:
-  oas:
-    name: Checks
-    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-    with:
-      python-version: '3.12'
-      apt-packages: ''
-      django-settings-module: openafval.conf.ci
-      oas-generate-command: ./bin/generate_api_schema.sh
-      schema-path: src/openafval/api/openapi.yaml
-      oas-artifact-name: openafval-api-oas
-      node-version-file: '.nvmrc'
-      spectral-version: '^6.15.0'
-      openapi-to-postman-version: '^5.0.0'
-      postman-artifact-name: openafval-api-postman-collection
-      openapi-generator-version: '^2.20.0'
+# name: OAS
+#
+# on:
+#   push:
+#     branches:
+#       - main
+#       - stable/*
+#     tags:
+#       - '*'
+#   pull_request:
+#   workflow_dispatch:
+#
+# jobs:
+#   oas:
+#     name: Checks
+#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+#     with:
+#       python-version: '3.12'
+#       apt-packages: ''
+#       django-settings-module: openafval.conf.ci
+#       oas-generate-command: ./bin/generate_api_schema.sh
+#       schema-path: src/openafval/api/openapi.yaml
+#       oas-artifact-name: openafval-api-oas
+#       node-version-file: '.nvmrc'
+#       spectral-version: '^6.15.0'
+#       openapi-to-postman-version: '^5.0.0'
+#       postman-artifact-name: openafval-api-postman-collection
+#       openapi-generator-version: '^2.20.0'


### PR DESCRIPTION
Disabling OAS CI checks for now due to a supply-chain security issue in a third-party dependency used by our linting tool (see asyncapi/spec-json-schemas#656).

Re-enable once the upstream issue is resolved.